### PR TITLE
Add copyable info fields to wool order

### DIFF
--- a/combinedbot.py
+++ b/combinedbot.py
@@ -355,7 +355,7 @@ class CombinedBot(commands.Bot):
 
     def normalize_name(self, name: str) -> str:
         """Normalize name into two words"""
-        cleaned = name.replace(",", " ").strip()    
+        cleaned = name.replace(",", " ").strip()
         parts = cleaned.split()
         if len(parts) >= 2:
             first = parts[0].strip().title()
@@ -364,6 +364,19 @@ class CombinedBot(commands.Bot):
         if len(parts) == 1:
             w = parts[0].strip().title()
             return f"{w} {w[0].upper()}"
+        return ''
+
+    def format_name_csv(self, name: str) -> str:
+        """Return name in 'Firstname,Lastname' format with no spaces around comma"""
+        cleaned = name.replace(",", " ").strip()
+        parts = cleaned.split()
+        if len(parts) >= 2:
+            first = parts[0].strip().title()
+            last = parts[1].strip().title()
+            return f"{first},{last}"
+        if len(parts) == 1:
+            w = parts[0].strip().title()
+            return f"{w},{w[0].upper()}"
         return ''
 
     def is_valid_field(self, value: str) -> bool:
@@ -774,13 +787,22 @@ async def wool_order(interaction: discord.Interaction, custom_email: str = None,
 
     # Create embed for clean output
     embed = discord.Embed(title="Wool Order", color=0xff6600)
-    
+
     # Add command output
     embed.add_field(name="", value=f"```{command}```", inline=False)
-    
+
     # Add email
     embed.add_field(name="**Email used:**", value=f"```{email}```", inline=False)
-    
+
+    # Add parsed fields above tip if present
+    if bot.is_valid_field(info['name']):
+        formatted = bot.format_name_csv(info['name'])
+        embed.add_field(name="Name:", value=f"```{formatted}```", inline=False)
+    if bot.is_valid_field(info['addr2']):
+        embed.add_field(name="Address Line 2:", value=f"```{info['addr2']}```", inline=False)
+    if bot.is_valid_field(info['notes']):
+        embed.add_field(name="Delivery Notes:", value=f"```{info['notes']}```", inline=False)
+
     # Add tip amount
     embed.add_field(name="", value=f"Tip: ${info['tip']}", inline=False)
     

--- a/tests/test_format_name_csv.py
+++ b/tests/test_format_name_csv.py
@@ -1,6 +1,7 @@
-import sys
 import types
+import sys
 import pathlib
+from types import SimpleNamespace
 
 class AttrStub:
     def __getattr__(self, name):
@@ -17,15 +18,14 @@ class DummyBotBase(AttrStub):
     def __init__(self, *args, **kwargs):
         pass
 
-# Prepare stub modules to satisfy imports
 discord_stub = AttrStub()
 discord_stub.Intents = DummyIntents
 discord_stub.app_commands = AttrStub()
-discord_stub.errors = types.SimpleNamespace(HTTPException=Exception)
-discord_stub.ext = types.SimpleNamespace(commands=types.SimpleNamespace(Bot=DummyBotBase))
-discord_stub.ui = types.SimpleNamespace(View=object, Button=object, button=lambda *a, **k: (lambda f: f))
+discord_stub.errors = SimpleNamespace(HTTPException=Exception)
+discord_stub.ext = SimpleNamespace(commands=SimpleNamespace(Bot=DummyBotBase))
+discord_stub.ui = SimpleNamespace(View=object, Button=object, button=lambda *a, **k: (lambda f: f))
 
-dotenv_stub = types.SimpleNamespace(load_dotenv=lambda: None)
+dotenv_stub = SimpleNamespace(load_dotenv=lambda: None)
 
 sys.modules.setdefault("discord", discord_stub)
 sys.modules.setdefault("discord.app_commands", discord_stub.app_commands)
@@ -35,7 +35,6 @@ sys.modules.setdefault("discord.ext.commands", discord_stub.ext.commands)
 sys.modules.setdefault("discord.ui", discord_stub.ui)
 sys.modules.setdefault("dotenv", dotenv_stub)
 
-# Load CombinedBot class without executing the whole script
 source_lines = []
 combinedbot_path = pathlib.Path(__file__).resolve().parents[1] / "combinedbot.py"
 with open(combinedbot_path, "r") as f:
@@ -49,21 +48,21 @@ exec("".join(source_lines), module.__dict__)
 CombinedBot = module.CombinedBot
 
 
-def test_normalize_two_words():
+def test_format_basic():
     bot = CombinedBot()
-    assert bot.normalize_name("john doe") == "John Doe"
+    assert bot.format_name_csv("john doe") == "John,Doe"
 
 
-def test_normalize_single_word():
+def test_format_with_comma_space():
     bot = CombinedBot()
-    assert bot.normalize_name("alice") == "Alice A"
+    assert bot.format_name_csv("john, doe") == "John,Doe"
 
 
-def test_normalize_empty():
+def test_format_single_word():
     bot = CombinedBot()
-    assert bot.normalize_name("") == ""
+    assert bot.format_name_csv("alice") == "Alice,A"
 
 
-def test_normalize_multi_word():
+def test_format_empty():
     bot = CombinedBot()
-    assert bot.normalize_name("charlie brown jr") == "Charlie Brown"
+    assert bot.format_name_csv("") == ""


### PR DESCRIPTION
## Summary
- add `format_name_csv` method to enforce comma-based names
- include name, address line 2, and delivery notes as copyable blocks in wool orders
- add tests for the new name formatter and update stubs for discord.ui

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407b257444832e93644e7461a24eb0