### PR TITLE
Introduce shared DB connection

### DIFF
--- a/tests/test_db_connection.py
+++ b/tests/test_db_connection.py
@@ -1,0 +1,16 @@
+import importlib.util
+import sqlite3
+import pathlib
+
+db_path = pathlib.Path(__file__).resolve().parents[1] / "db.py"
+spec = importlib.util.spec_from_file_location("db", db_path)
+db = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(db)
+
+
+def test_connection_singleton():
+    conn1 = db.get_connection()
+    conn2 = db.get_connection()
+    assert conn1 is conn2
+    assert isinstance(conn1, sqlite3.Connection)
+


### PR DESCRIPTION
## Summary
- centralize SQLite connection in `db.py`
- expose helper functions `get_connection()` and `close_connection()`
- refactor data access helpers to reuse the shared connection
- use new helpers in `CombinedBot`
- close the database when the bot shuts down
- test connection sharing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e0b6e428832ea5d994b6e5066932