### PR TITLE
Add fallback search for webhook tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A unified Discord bot that combines two essential functionalities:
 - **`/fusion_order`** - Generate Fusion order commands with email from pool
 - **`/wool_order`** - Generate Wool order commands
 - **Automatic embed parsing** from ticket bots
+- **Order webhook tracking** - Use `/send_tracking` after a webhook posts to send tracking info to the ticket
+- **Webhook cache debugging** - `/debug_webhooks` lists cached orders and helps diagnose tracking issues
 - **Card & Email pools** with SQLite storage
 - **Comprehensive logging** to JSON, CSV, and TXT files
 - **Custom card/email support** - Use your own cards/emails without touching the pool

--- a/combinedbot.py
+++ b/combinedbot.py
@@ -89,6 +89,8 @@ OWNER_ID = int(os.getenv('OWNER_ID')) if os.getenv('OWNER_ID') else None
 OPENER_CHANNEL_ID = int(os.getenv('OPENER_CHANNEL_ID')) if os.getenv('OPENER_CHANNEL_ID') else None
 ROLE_PING_ID = os.getenv('ROLE_PING_ID', '1352022044614590494')
 ORDER_CHANNEL_MENTION = os.getenv('ORDER_CHANNEL_MENTION', '<#1350935337269985334>')
+# channel where order webhooks are posted
+WEBHOOK_CHANNEL_ID = helpers.WEBHOOK_CHANNEL_ID
 
 EXP_MONTH = '06'
 EXP_YEAR = '30'
@@ -186,6 +188,15 @@ def main():
             else:
                 await message.add_reaction("❌")
                 await message.channel.send(f"{message.author.mention} ❌ {error}", delete_after=10)
+
+        if message.webhook_id and message.channel.id == WEBHOOK_CHANNEL_ID and message.embeds:
+            data = helpers.parse_webhook_order(message.embeds[0])
+            name = data.get('name', '').lower()
+            addr = data.get('address', '').lower()
+            if name and addr:
+                helpers.ORDER_WEBHOOK_CACHE[(name, addr)] = data
+                print(f"[DEBUG] stored webhook for {(name, addr)}")
+
         await bot.process_commands(message)
 
     channel_commands.setup(bot)

--- a/tests/test_parse_webhook_order.py
+++ b/tests/test_parse_webhook_order.py
@@ -1,0 +1,65 @@
+import types
+import sys
+import pathlib
+from types import SimpleNamespace
+
+class AttrStub:
+    def __getattr__(self, name):
+        return AttrStub()
+    def __call__(self, *args, **kwargs):
+        return AttrStub()
+
+class DummyEmbed:
+    def __init__(self, url=""):
+        self.url = url
+        self.author = SimpleNamespace(url=url)
+        self.fields = []
+    def add_field(self, name, value, inline=False):
+        self.fields.append(SimpleNamespace(name=name, value=value))
+
+discord_stub = AttrStub()
+discord_stub.Embed = DummyEmbed
+discord_stub.app_commands = AttrStub()
+discord_stub.errors = SimpleNamespace(HTTPException=Exception)
+discord_stub.ext = SimpleNamespace(commands=SimpleNamespace(Bot=AttrStub()))
+discord_stub.ui = SimpleNamespace(View=object, Button=object, button=lambda *a, **k: (lambda f: f))
+
+dotenv_stub = SimpleNamespace(load_dotenv=lambda: None)
+
+sys.modules.setdefault("discord", discord_stub)
+sys.modules.setdefault("discord.app_commands", discord_stub.app_commands)
+sys.modules.setdefault("discord.errors", discord_stub.errors)
+sys.modules.setdefault("discord.ext", discord_stub.ext)
+sys.modules.setdefault("discord.ext.commands", discord_stub.ext.commands)
+sys.modules.setdefault("discord.ui", discord_stub.ui)
+sys.modules.setdefault("dotenv", dotenv_stub)
+
+import importlib
+
+helpers_path = pathlib.Path(__file__).resolve().parents[1] / "bot" / "utils" / "helpers.py"
+spec = importlib.util.spec_from_file_location("helpers", helpers_path)
+helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helpers)
+
+parse_webhook_order = helpers.parse_webhook_order
+Embed = DummyEmbed
+
+
+def test_parse_webhook_order_basic():
+    embed = Embed(url="https://track.example.com")
+    embed.add_field(name="Store", value="Pizza Place")
+    embed.add_field(name="Estimated Arrival", value="5 PM")
+    embed.add_field(name="Name", value="John Doe")
+    embed.add_field(name="Delivery Address", value="123 Street")
+    embed.add_field(name="Order Items", value="Pizza")
+
+    result = parse_webhook_order(embed)
+
+    assert result == {
+        "store": "Pizza Place",
+        "eta": "5 PM",
+        "name": "John Doe",
+        "address": "123 Street",
+        "items": "Pizza",
+        "tracking": "https://track.example.com",
+    }


### PR DESCRIPTION
## Summary
- store webhook channel ID in helpers for sharing
- restrict order webhook caching to the configured channel
- when `/send_tracking` cache misses, scan the webhook channel history for the latest matching embed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68473c8c9a88832e94fd59929bbbfa10