### PR TITLE
Add debug tools for send_tracking

### DIFF
--- a/bot/commands/order.py
+++ b/bot/commands/order.py
@@ -378,3 +378,31 @@ def setup(bot: commands.Bot):
         await interaction.response.send_message(embed=e)
         helpers.ORDER_WEBHOOK_CACHE.pop((name, addr), None)
 
+    @bot.tree.command(name='debug_tracking', description='Debug webhook lookup')
+    async def debug_tracking(interaction: discord.Interaction, search_limit: int = 50):
+        """Display information about the most recent order embed and cache."""
+        if not owner_only(interaction):
+            return await interaction.response.send_message('❌ You are not authorized.', ephemeral=True)
+
+        channel = interaction.guild.get_channel(1352067371006693499)
+        if channel is None:
+            return await interaction.response.send_message('❌ Tracking channel not found.', ephemeral=True)
+
+        embed = await fetch_order_embed(channel, search_limit=search_limit)
+        if embed is None:
+            return await interaction.response.send_message('❌ Could not locate order embed.', ephemeral=True)
+
+        info = parse_fields(embed)
+        name = info.get('name', '').lower()
+        addr = info.get('address', info.get('addr2', '')).lower()
+        data = helpers.ORDER_WEBHOOK_CACHE.get((name, addr))
+
+        debug = discord.Embed(title='Tracking Debug', color=0xffff00)
+        debug.add_field(name='Lookup Key', value=f'{name} | {addr}', inline=False)
+        debug.add_field(name='Cache Hit', value='Yes' if data else 'No', inline=False)
+        if not data:
+            keys = [f'{k[0]} | {k[1]}' for k in helpers.ORDER_WEBHOOK_CACHE.keys()]
+            debug.add_field(name='Cache Keys', value='; '.join(keys) or 'None', inline=False)
+
+        await interaction.response.send_message(embed=debug, ephemeral=True)
+

--- a/combinedbot.py
+++ b/combinedbot.py
@@ -134,8 +134,10 @@ class CombinedBot(commands.Bot):
     def get_pool_counts(self) -> Tuple[int, int]:
         return db_get_pool_counts()
 
-    async def fetch_order_embed(self, channel: discord.TextChannel):
-        return await helpers.fetch_order_embed(channel)
+    async def fetch_order_embed(
+        self, channel: discord.TextChannel, search_limit: int = 25
+    ):
+        return await helpers.fetch_order_embed(channel, search_limit=search_limit)
 
     def parse_fields(self, embed: discord.Embed) -> dict:
         return helpers.parse_fields(embed)


### PR DESCRIPTION
## Summary
- search recent history for order embed instead of only first message
- expose search limit parameter via `CombinedBot.fetch_order_embed`
- add `/debug_tracking` command to help inspect webhook lookup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684753fbc618832e879fb3cb22ac0245