### PR TITLE
Add admin command to update card expiration settings

### DIFF
--- a/bot/commands/admin.py
+++ b/bot/commands/admin.py
@@ -13,6 +13,7 @@ from logging_utils import log_command_output, get_recent_logs, get_full_logs, ge
 from ..utils.card_validator import CardValidator
 from ..utils.helpers import owner_only
 import db
+import config
 
 # Database path - supports both local development and Railway/production
 DB_PATH = os.getenv('DB_PATH', os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'data', 'pool.db'))
@@ -997,7 +998,7 @@ def setup(bot: commands.Bot):
         )
         
         embed.set_footer(text=f"Changed by {interaction.user}")
-        
+
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
     @bot.tree.command(name='toggle_cashapp', description='(Admin) Enable or disable the CashApp payment button (legacy)')
@@ -1035,5 +1036,51 @@ def setup(bot: commands.Bot):
         )
         
         embed.set_footer(text=f"Changed by {interaction.user}")
-        
+
         await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @bot.tree.command(name='set_expiration', description='(Admin) Update the card expiration month and/or year used in all commands')
+    @app_commands.describe(
+        month='Expiration month (2 digits, e.g. 04)',
+        year='Expiration year (2 digits, e.g. 31)',
+    )
+    async def set_expiration(interaction: discord.Interaction, month: str = None, year: str = None):
+        if not owner_only(interaction):
+            return await interaction.response.send_message("❌ Unauthorized.", ephemeral=True)
+
+        if month is None and year is None:
+            return await interaction.response.send_message(
+                f"Current expiration: **{config.EXP_MONTH}/{config.EXP_YEAR}**\n"
+                "Provide `month` and/or `year` to update.",
+                ephemeral=True
+            )
+
+        if month is not None:
+            if not month.isdigit() or len(month) != 2 or not (1 <= int(month) <= 12):
+                return await interaction.response.send_message(
+                    "❌ Invalid month. Must be a 2-digit number between 01 and 12 (e.g. `04`).",
+                    ephemeral=True
+                )
+
+        if year is not None:
+            if not year.isdigit() or len(year) != 2:
+                return await interaction.response.send_message(
+                    "❌ Invalid year. Must be exactly 2 digits (e.g. `31`).",
+                    ephemeral=True
+                )
+
+        old_month = config.EXP_MONTH
+        old_year = config.EXP_YEAR
+
+        if month is not None:
+            config.EXP_MONTH = month
+            db.set_config_setting('EXP_MONTH', month)
+
+        if year is not None:
+            config.EXP_YEAR = year
+            db.set_config_setting('EXP_YEAR', year)
+
+        await interaction.response.send_message(
+            f"✅ Expiration updated: **{old_month}/{old_year}** → **{config.EXP_MONTH}/{config.EXP_YEAR}**",
+            ephemeral=True
+        )

--- a/bot/commands/feed.py
+++ b/bot/commands/feed.py
@@ -3,7 +3,7 @@ from discord import app_commands
 from discord.ext import commands
 from ..utils.helpers import owner_only
 import db
-from config import EXP_MONTH, EXP_YEAR, ZIP_CODE
+import config
 
 def setup(bot: commands.Bot):
     @bot.tree.command(name='feed', description='Generate feed command(s) with VCC from pool')
@@ -41,7 +41,7 @@ def setup(bot: commands.Bot):
 
             number, cvv = card_result
             # Format: /feed orderinfo: link,card_number,exp_month/exp_year,cvv,zip_code
-            feed_cmd = f"/feed orderinfo: {link},{number},{EXP_MONTH}/{EXP_YEAR},{cvv},{ZIP_CODE}"
+            feed_cmd = f"/feed orderinfo: {link},{number},{config.EXP_MONTH}/{config.EXP_YEAR},{cvv},{config.ZIP_CODE}"
             feed_commands.append(feed_cmd)
 
         if not feed_commands:
@@ -101,7 +101,7 @@ def setup(bot: commands.Bot):
                     break
 
                 number, cvv = card_result
-                feed_cmd = f"/feed orderinfo: {link},{number},{EXP_MONTH}/{EXP_YEAR},{cvv},{ZIP_CODE}"
+                feed_cmd = f"/feed orderinfo: {link},{number},{config.EXP_MONTH}/{config.EXP_YEAR},{cvv},{config.ZIP_CODE}"
                 all_commands.append(feed_cmd)
 
         if not all_commands:

--- a/bot/commands/order.py
+++ b/bot/commands/order.py
@@ -26,7 +26,7 @@ from ..utils.card_validator import CardValidator
 from ..utils.channel_status import rename_history
 from logging_utils import log_command_output
 import db
-from config import EXP_MONTH, EXP_YEAR, ZIP_CODE
+import config
 
 # Database path - supports both local development and Railway/production
 DB_PATH = os.getenv('DB_PATH', os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'data', 'pool.db'))
@@ -93,7 +93,7 @@ def setup(bot: commands.Bot):
             card_source = "pool"
 
         raw_name = info['name']
-        base_command = f"{info['link']},{number},{EXP_MONTH},{EXP_YEAR},{cvv},{ZIP_CODE}"
+        base_command = f"{info['link']},{number},{config.EXP_MONTH},{config.EXP_YEAR},{cvv},{config.ZIP_CODE}"
         if email:
             base_command += f",{email}"
 
@@ -555,7 +555,7 @@ def setup(bot: commands.Bot):
             was_last_email = pool_counts['emails'][email_pool_used] == 0
 
         raw_name = info['name']
-        parts = [f"/order uber order_details:{info['link']},{number},{EXP_MONTH},{EXP_YEAR},{cvv},{ZIP_CODE},{email}"]
+        parts = [f"/order uber order_details:{info['link']},{number},{config.EXP_MONTH},{config.EXP_YEAR},{cvv},{config.ZIP_CODE},{email}"]
         if is_valid_field(raw_name):
             name = normalize_name(raw_name)
             parts.append(f"override_name:{name}")
@@ -787,7 +787,7 @@ def setup(bot: commands.Bot):
             pool_counts = bot.get_pool_counts()
             was_last_email = pool_counts['emails'][email_pool_used] == 0
 
-        command = f"{info['link']},{number},{EXP_MONTH}/{EXP_YEAR},{cvv},{ZIP_CODE},{email}"
+        command = f"{info['link']},{number},{config.EXP_MONTH}/{config.EXP_YEAR},{cvv},{config.ZIP_CODE},{email}"
 
         if card_source == "pool" or email_source == "pool":
             log_command_output(
@@ -912,7 +912,7 @@ def setup(bot: commands.Bot):
             was_last_email = pool_counts['emails'][email_pool_used] == 0
 
         # Format: !otp email,link,cardnum,exp_month,exp_year,cvv,zip
-        command = f"!otp {email},{info['link']},{number},{EXP_MONTH},{EXP_YEAR},{cvv},{ZIP_CODE}"
+        command = f"!otp {email},{info['link']},{number},{config.EXP_MONTH},{config.EXP_YEAR},{cvv},{config.ZIP_CODE}"
 
         if card_source == "pool" or email_source == "pool":
             log_command_output(

--- a/bot/commands/vcc.py
+++ b/bot/commands/vcc.py
@@ -3,7 +3,7 @@ from discord import app_commands
 from discord.ext import commands
 from ..utils.helpers import owner_only
 import db
-from config import EXP_MONTH, EXP_YEAR, ZIP_CODE
+import config
 
 def setup(bot: commands.Bot):
     @bot.tree.command(name='vcc', description='Pull a card from the pool in order format')
@@ -20,6 +20,6 @@ def setup(bot: commands.Bot):
 
         number, cvv = card_result
 
-        card_format = f"{number},{EXP_MONTH}/{EXP_YEAR},{cvv},{ZIP_CODE}"
+        card_format = f"{number},{config.EXP_MONTH}/{config.EXP_YEAR},{cvv},{config.ZIP_CODE}"
 
         await interaction.followup.send(f"```{card_format}```", ephemeral=True)

--- a/combinedbot.py
+++ b/combinedbot.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 from pathlib import Path
 from typing import Optional, Tuple
 import asyncio
-from config import EXP_MONTH, EXP_YEAR, ZIP_CODE
+import config
 
 try:
     from db import (
@@ -122,9 +122,11 @@ class CombinedBot(commands.Bot):
 
     def init_database(self):
         init_db()
+        config.load_from_db()
 
     def init_pool_db(self):
         init_db()
+        config.load_from_db()
 
     async def close(self):
         close_connection()

--- a/config.py
+++ b/config.py
@@ -2,7 +2,15 @@
 
 import os
 
-# Payment card constants
+# Payment card constants (defaults; overridden by DB via load_from_db())
 EXP_MONTH = '04'
 EXP_YEAR = '31'
 ZIP_CODE = '19104'
+
+
+def load_from_db():
+    """Load mutable config values from the database, falling back to the defaults above."""
+    global EXP_MONTH, EXP_YEAR
+    import db
+    EXP_MONTH = db.get_config_setting('EXP_MONTH', EXP_MONTH)
+    EXP_YEAR = db.get_config_setting('EXP_YEAR', EXP_YEAR)

--- a/db.py
+++ b/db.py
@@ -79,6 +79,14 @@ def init_db():
         )
     ''')
 
+    # Table for storing bot configuration settings
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS config_settings (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+    ''')
+
     # Initialize default payment methods if they don't exist
     default_methods = ['zelle', 'venmo', 'paypal', 'cashapp', 'crypto']
     for method in default_methods:
@@ -360,6 +368,26 @@ def get_all_payment_settings() -> dict:
     cursor.execute('SELECT method, enabled FROM payment_settings')
     rows = cursor.fetchall()
     return {method: bool(enabled) for method, enabled in rows}
+
+
+def get_config_setting(key: str, default: str = None) -> str:
+    """Get a bot configuration value by key."""
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute('SELECT value FROM config_settings WHERE key = ?', (key,))
+    row = cursor.fetchone()
+    return row[0] if row else default
+
+
+def set_config_setting(key: str, value: str) -> None:
+    """Persist a bot configuration value."""
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        'INSERT OR REPLACE INTO config_settings (key, value) VALUES (?, ?)',
+        (key, value)
+    )
+    conn.commit()
 
 
 # Initialize DB on import and create the shared connection


### PR DESCRIPTION
## Summary
This PR adds the ability for admins to dynamically update card expiration month and year through a new Discord command, with values persisted to the database and loaded on bot startup.

## Key Changes
- **New admin command** (`/set_expiration`): Allows owners to view and update `EXP_MONTH` and `EXP_YEAR` with validation
  - Validates month as 2-digit number between 01-12
  - Validates year as exactly 2 digits
  - Shows current values when called without arguments
  - Displays before/after values in confirmation message

- **Database persistence**: 
  - Added `config_settings` table to store configuration key-value pairs
  - Implemented `get_config_setting()` and `set_config_setting()` functions in `db.py`

- **Config module refactoring**:
  - Added `load_from_db()` function to load mutable settings from database on startup
  - Maintains default values as fallbacks
  - Called during bot initialization in `combinedbot.py`

- **Import standardization**: Changed all config imports from `from config import EXP_MONTH, EXP_YEAR, ZIP_CODE` to `import config` across multiple command modules for consistency and to support dynamic value updates

## Implementation Details
- The `set_expiration` command updates both the in-memory config module and persists to database using `INSERT OR REPLACE`
- Config values are loaded from database during bot initialization, allowing changes to persist across restarts
- All existing commands that use expiration values now reference them via `config.EXP_MONTH` and `config.EXP_YEAR` to ensure they use the latest values
- Minor whitespace cleanup in existing code

https://claude.ai/code/session_014G3La9kyogWwBhtAJXjFvF